### PR TITLE
Remove Course Materials Assistant header and branding

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,15 +6,11 @@
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
     <meta http-equiv="Pragma" content="no-cache">
     <meta http-equiv="Expires" content="0">
-    <title>Course Materials Assistant</title>
+    <title>RAG Chat Bot</title>
     <link rel="stylesheet" href="style.css?v=9">
 </head>
 <body>
     <div class="container">
-        <header>
-            <h1>Course Materials Assistant</h1>
-            <p class="subtitle">Ask questions about courses, instructors, and content</p>
-        </header>
 
         <div class="main-content">
             <!-- Left Sidebar -->

--- a/frontend/script.js
+++ b/frontend/script.js
@@ -149,7 +149,7 @@ function escapeHtml(text) {
 async function createNewSession() {
     currentSessionId = null;
     chatMessages.innerHTML = '';
-    addMessage('Welcome to the Course Materials Assistant! I can help you with questions about courses, lessons and specific content. What would you like to know?', 'assistant', null, true);
+    addMessage('Welcome! I can help you with questions about courses, lessons and specific content. What would you like to know?', 'assistant', null, true);
 }
 
 // Load course statistics

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -46,26 +46,6 @@ body {
     padding: 0;
 }
 
-/* Header - Hidden */
-header {
-    display: none;
-}
-
-header h1 {
-    font-size: 1.75rem;
-    font-weight: 700;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-    margin: 0;
-}
-
-.subtitle {
-    font-size: 0.95rem;
-    color: var(--text-secondary);
-    margin-top: 0.5rem;
-}
 
 /* Main Content Area with Sidebar */
 .main-content {
@@ -670,13 +650,6 @@ details[open] .suggested-header::before {
         order: 1;
     }
     
-    header {
-        padding: 1rem;
-    }
-    
-    header h1 {
-        font-size: 1.5rem;
-    }
     
     .chat-messages {
         padding: 1rem;


### PR DESCRIPTION
This PR addresses issue #2 by reverting the header to an older version.

## Changes Made
- Removed "Course Materials Assistant" title from page
- Removed header section with h1 and subtitle
- Updated welcome message to remove branding
- Cleaned up related CSS styles
- Changed page title to "RAG Chat Bot"

Closes #2

🤖 Generated with [Claude Code](https://claude.ai/code)